### PR TITLE
Declare canRequestFilterKeyEvents so the Home Button Fix receives key events

### DIFF
--- a/android/app/src/main/res/xml/accessibility_service_config.xml
+++ b/android/app/src/main/res/xml/accessibility_service_config.xml
@@ -2,4 +2,5 @@
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:accessibilityFeedbackType="feedbackGeneric"
     android:accessibilityFlags="flagRequestFilterKeyEvents"
+    android:canRequestFilterKeyEvents="true"
     android:canRetrieveWindowContent="false" />


### PR DESCRIPTION
`accessibility_service_config.xml` sets `flagRequestFilterKeyEvents` but never declares the matching capability. Android ignores the flag without `android:canRequestFilterKeyEvents="true"`, so the service binds with no capabilities and `onKeyEvent` never fires. Home button presses fall through to the stock launcher, which makes Method 2 in the README a no-op.

Seen on a Hisense Google TV (Android 12):

- before: `dumpsys accessibility` → `Service[label=LTvLauncher Home Button Fix, feedbackType[FEEDBACK_GENERIC], capabilities=0, ...]`; Home opens Google TV
- after: `capabilities=8`; Home logs `START u0 {flg=0x14000000 cmp=com.leanbitlab.ltvL/.MainActivity} from uid 10115` and opens LtvLauncher

One attribute added. Note for testing: `adb shell input keyevent KEYCODE_HOME` bypasses the accessibility key filter, so this has to be checked with the physical remote.