### PR TITLE
Add a Start on boot option for devices whose stock launcher owns HOME

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
         android:required="false" />
 
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <uses-permission android:name="android.permission.READ_TV_LISTINGS" />
     <uses-permission android:name="com.android.providers.tv.permission.READ_EPG_DATA" />
@@ -105,6 +106,12 @@
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>
         </service>
+
+        <receiver android:name=".BootReceiver" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
         <service
             android:name=".LauncherAccessibilityService"

--- a/android/app/src/main/java/com/leanbitlab/ltvL/BootReceiver.java
+++ b/android/app/src/main/java/com/leanbitlab/ltvL/BootReceiver.java
@@ -1,0 +1,23 @@
+package com.leanbitlab.ltvL;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Starts the launcher after boot when the "Start on boot" setting is on. Meant for devices whose
+ * stock launcher always wins HOME resolution (Google TV, Fire TV). Android 10+ only allows this
+ * background activity start while the app holds an exemption, e.g. the Home Button Fix
+ * accessibility service is enabled or the overlay permission is granted; otherwise it is dropped.
+ */
+public class BootReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (!Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) return;
+        // shared_preferences stores Flutter keys in this file with a "flutter." prefix.
+        boolean enabled = context.getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
+                .getBoolean("flutter.start_on_boot", false);
+        if (!enabled) return;
+        context.startActivity(new Intent(context, MainActivity.class).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
+    }
+}

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -183,6 +183,7 @@
     "dataUsage": "استخدام البيانات",
     "networkIndicator": "مؤشر الشبكة",
     "homeButtonFix": "إصلاح زر الصفحة الرئيسية (Google TV)",
+    "startOnBoot": "التشغيل عند بدء الجهاز (Google TV / Fire TV)",
     "appLanguage": "اللغة",
     "systemDefault": "افتراضي النظام",
     "english": "الإنجليزية",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -183,6 +183,7 @@
     "dataUsage": "Datennutzung",
     "networkIndicator": "Netzwerkindikator",
     "homeButtonFix": "Home-Taste-Fix (Google TV)",
+    "startOnBoot": "Beim Einschalten starten (Google TV / Fire TV)",
     "appLanguage": "Sprache",
     "systemDefault": "Systemstandard",
     "english": "Englisch",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -183,6 +183,7 @@
     "dataUsage": "Data Usage",
     "networkIndicator": "Network Indicator",
     "homeButtonFix": "Home Button Fix (Google TV)",
+    "startOnBoot": "Start on boot (Google TV / Fire TV)",
     "appLanguage": "Language",
     "systemDefault": "System Default",
     "english": "English",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -183,6 +183,7 @@
     "dataUsage": "Uso de datos",
     "networkIndicator": "Indicador de red",
     "homeButtonFix": "Corrección del botón Inicio (Google TV)",
+    "startOnBoot": "Iniciar al encender (Google TV / Fire TV)",
     "appLanguage": "Idioma",
     "systemDefault": "Predeterminado del sistema",
     "english": "Inglés",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -183,6 +183,7 @@
     "dataUsage": "Utilisation des données",
     "networkIndicator": "Indicateur réseau",
     "homeButtonFix": "Correction du bouton Accueil (Google TV)",
+    "startOnBoot": "Lancer au démarrage (Google TV / Fire TV)",
     "appLanguage": "Langue",
     "systemDefault": "Système par défaut",
     "english": "Anglais",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -183,6 +183,7 @@
     "dataUsage": "डेटा उपयोग",
     "networkIndicator": "नेटवर्क संकेतक",
     "homeButtonFix": "होम बटन फिक्स (Google TV)",
+    "startOnBoot": "बूट पर शुरू करें (Google TV / Fire TV)",
     "appLanguage": "भाषा",
     "systemDefault": "सिस्टम डिफ़ॉल्ट",
     "english": "अंग्रेज़ी",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -183,6 +183,7 @@
     "dataUsage": "Utilizzo dati",
     "networkIndicator": "Indicatore di rete",
     "homeButtonFix": "Fix pulsante Home (Google TV)",
+    "startOnBoot": "Avvia all'accensione (Google TV / Fire TV)",
     "appLanguage": "Lingua",
     "systemDefault": "Predefinito di sistema",
     "english": "Inglese",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -183,6 +183,7 @@
     "dataUsage": "データ使用量",
     "networkIndicator": "ネットワークインジケーター",
     "homeButtonFix": "ホームボタン修正 (Google TV)",
+    "startOnBoot": "起動時に開始 (Google TV / Fire TV)",
     "appLanguage": "言語",
     "systemDefault": "システムのデフォルト",
     "english": "英語",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -183,6 +183,7 @@
     "dataUsage": "데이터 사용량",
     "networkIndicator": "네트워크 표시기",
     "homeButtonFix": "홈 버튼 수정 (Google TV)",
+    "startOnBoot": "부팅 시 시작 (Google TV / Fire TV)",
     "appLanguage": "언어",
     "systemDefault": "시스템 기본값",
     "english": "영어",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -183,6 +183,7 @@
     "dataUsage": "Uso de dados",
     "networkIndicator": "Indicador de rede",
     "homeButtonFix": "Correção do botão Home (Google TV)",
+    "startOnBoot": "Iniciar ao ligar (Google TV / Fire TV)",
     "appLanguage": "Idioma",
     "systemDefault": "Padrão do sistema",
     "english": "Inglês",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -183,6 +183,7 @@
     "dataUsage": "Использование данных",
     "networkIndicator": "Индикатор сети",
     "homeButtonFix": "Исправление кнопки «Домой» (Google TV)",
+    "startOnBoot": "Запускать при включении (Google TV / Fire TV)",
     "appLanguage": "Язык",
     "systemDefault": "Системный по умолчанию",
     "english": "Английский",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -183,6 +183,7 @@
     "dataUsage": "Veri Kullanımı",
     "networkIndicator": "Ağ Göstergesi",
     "homeButtonFix": "Ana Sayfa Düğmesi Düzeltmesi (Google TV)",
+    "startOnBoot": "Açılışta başlat (Google TV / Fire TV)",
     "appLanguage": "Dil",
     "systemDefault": "Sistem Varsayılanı",
     "english": "İngilizce",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -183,6 +183,7 @@
     "dataUsage": "Використання даних",
     "networkIndicator": "Індикатор мережі",
     "homeButtonFix": "Виправлення кнопки «Домівка» (Google TV)",
+    "startOnBoot": "Запускати після завантаження (Google TV / Fire TV)",
     "appLanguage": "Мова",
     "systemDefault": "Системна мова за замовчуванням",
     "english": "Англійська",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -183,6 +183,7 @@
     "dataUsage": "数据使用",
     "networkIndicator": "网络指示器",
     "homeButtonFix": "Home 键修复（Google TV）",
+    "startOnBoot": "开机时启动 (Google TV / Fire TV)",
     "appLanguage": "语言",
     "systemDefault": "跟随系统",
     "english": "英语",

--- a/lib/providers/settings_service.dart
+++ b/lib/providers/settings_service.dart
@@ -45,6 +45,7 @@ const String _screensaverClockStyleKey = "screensaver_clock_style";
 const String _timeBasedWallpaperEnabledKey = "time_based_wallpaper_enabled";
 const String _showInputsWidgetInStatusBarKey = "show_inputs_widget_in_status_bar";
 const String _showContinueWatchingKey = "show_continue_watching";
+const String _startOnBootKey = "start_on_boot";
 const String _showNotificationsWidgetInStatusBarKey = "show_notifications_widget_in_status_bar";
 const String _autoHideNotificationsWidgetKey = "auto_hide_notifications_widget";
 const String _appLanguageKey = "app_language";
@@ -104,6 +105,7 @@ class SettingsService extends ChangeNotifier {
   late bool _timeBasedWallpaperEnabled;
   late bool _showInputsWidgetInStatusBar;
   late bool _showContinueWatching;
+  late bool _startOnBoot;
   late bool _showNotificationsWidgetInStatusBar;
   late bool _autoHideNotificationsWidget;
   late String _appLanguage;
@@ -147,6 +149,7 @@ class SettingsService extends ChangeNotifier {
 
   bool get showInputsWidgetInStatusBar => _showInputsWidgetInStatusBar;
   bool get showContinueWatching => _showContinueWatching;
+  bool get startOnBoot => _startOnBoot;
   bool get showNotificationsWidgetInStatusBar => _showNotificationsWidgetInStatusBar;
   bool get autoHideNotificationsWidget => _autoHideNotificationsWidget;
   bool get showWeatherInStatusBar => _showWeatherInStatusBar;
@@ -199,6 +202,7 @@ class SettingsService extends ChangeNotifier {
     _timeBasedWallpaperEnabled = _sharedPreferences.getBool(_timeBasedWallpaperEnabledKey) ?? false;
     _showInputsWidgetInStatusBar = _sharedPreferences.getBool(_showInputsWidgetInStatusBarKey) ?? true;
     _showContinueWatching = _sharedPreferences.getBool(_showContinueWatchingKey) ?? true;
+    _startOnBoot = _sharedPreferences.getBool(_startOnBootKey) ?? false;
     _showNotificationsWidgetInStatusBar = _sharedPreferences.getBool(_showNotificationsWidgetInStatusBarKey) ?? true;
     _autoHideNotificationsWidget = _sharedPreferences.getBool(_autoHideNotificationsWidgetKey) ?? false;
     _appLanguage = _sharedPreferences.getString(_appLanguageKey) ?? "";
@@ -232,6 +236,7 @@ class SettingsService extends ChangeNotifier {
       _timeBasedWallpaperEnabledKey: _timeBasedWallpaperEnabled,
       _showInputsWidgetInStatusBarKey: _showInputsWidgetInStatusBar,
       _showContinueWatchingKey: _showContinueWatching,
+      _startOnBootKey: _startOnBoot,
       _showNotificationsWidgetInStatusBarKey: _showNotificationsWidgetInStatusBar,
       _autoHideNotificationsWidgetKey: _autoHideNotificationsWidget,
       _appLanguageKey: _appLanguage,
@@ -395,6 +400,12 @@ class SettingsService extends ChangeNotifier {
   Future<void> setShowContinueWatching(bool show) async {
     await _sharedPreferences.setBool(_showContinueWatchingKey, show);
     _showContinueWatching = show;
+    notifyListeners();
+  }
+
+  Future<void> setStartOnBoot(bool enabled) async {
+    await _sharedPreferences.setBool(_startOnBootKey, enabled);
+    _startOnBoot = enabled;
     notifyListeners();
   }
 

--- a/lib/widgets/settings/accessibility_page.dart
+++ b/lib/widgets/settings/accessibility_page.dart
@@ -2,6 +2,7 @@ import 'package:flauncher/flauncher_channel.dart';
 import 'package:flauncher/l10n/app_localizations.dart';
 import 'package:flauncher/providers/apps_service.dart';
 import 'package:flauncher/providers/launcher_state.dart';
+import 'package:flauncher/providers/settings_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -57,6 +58,7 @@ class _AccessibilityPageState extends State<AccessibilityPage> with WidgetsBindi
   Widget build(BuildContext context) {
     AppLocalizations localizations = AppLocalizations.of(context)!;
     LauncherState launcherState = context.watch<LauncherState>();
+    SettingsService settingsService = context.watch<SettingsService>();
     bool isDefault = launcherState.isDefaultLauncher;
 
     return Column(
@@ -127,6 +129,24 @@ class _AccessibilityPageState extends State<AccessibilityPage> with WidgetsBindi
                       _showAccessibilityPermissionGuide(context);
                     }
                   },
+                ),
+                const SizedBox(height: 8),
+                FocusableSettingsTile(
+                  leading: Icon(
+                    Icons.power_settings_new,
+                    color: settingsService.startOnBoot ? Colors.green : Colors.white54,
+                  ),
+                  title: Text(
+                    localizations.startOnBoot,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  trailing: Text(
+                    settingsService.startOnBoot ? localizations.enabled : localizations.disabled,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: settingsService.startOnBoot ? Colors.green : Colors.white54,
+                        ),
+                  ),
+                  onPressed: () => settingsService.setStartOnBoot(!settingsService.startOnBoot),
                 ),
                 const SizedBox(height: 16),
                 Padding(


### PR DESCRIPTION
On Google TV and Fire TV the stock launcher wins HOME resolution at boot (intent-filter priority, see #130), so even with the Home Button Fix on, the TV comes up on the stock home screen and the user has to press Home once. This adds an opt-in **Start on boot** tile under Settings → Accessibility, next to Home Button Fix. Off by default.

How it works:
- `BootReceiver` on `BOOT_COMPLETED` reads the flag straight from the shared_preferences file (`FlutterSharedPreferences` / `flutter.start_on_boot`) so it does not need the Flutter engine, then starts `MainActivity` with `FLAG_ACTIVITY_NEW_TASK`.
- `SettingsService` gets `startOnBoot` / `setStartOnBoot`, and the key is included in the backup/restore map.
- String added to all 14 ARB files.

Android 10+ only allows the background activity start while the app holds an exemption; in practice that is the Home Button Fix accessibility service being enabled, or the overlay permission. Without either the system drops the start silently. The receiver's javadoc says so.

Verification:
- Builds clean with the pinned toolchain (Flutter 3.24.5, JDK 21).
- The receiver itself is verified on a Hisense Google TV (Android 12): after `adb reboot`, `sys.boot_completed` at 17:09:33, then `START u0 {flg=0x10000000 cmp=com.leanbitlab.ltvL/.MainActivity} from uid 10115` at 17:09:57 with `Background activity start for com.leanbitlab.ltvL allowed because SYSTEM_ALERT_WINDOW permission is granted`, and the launcher in the foreground. Expect ~25 s of stock home before it takes over; the TV delays app boot broadcasts.
- The settings tile is not device-tested: current master crashes on my device's existing 2026.08.10 data at startup (`AppsService.sortCategory`, `application.categoryOrders[category.id]!` null check, apps_service.dart:392), which is unrelated to this change. Happy to open that as a separate issue with the full stack if useful.