### PR TITLE
Fix "Continue Watching" row

### DIFF
--- a/android/app/src/main/java/com/leanbitlab/ltvL/MainActivity.java
+++ b/android/app/src/main/java/com/leanbitlab/ltvL/MainActivity.java
@@ -1135,48 +1135,53 @@ public class MainActivity extends FlutterActivity {
 
     private List<Map<String, Object>> getWatchNextPrograms() {
         List<Map<String, Object>> list = new ArrayList<>();
-        try {
-            String[] projection = {
-                TvContract.WatchNextPrograms._ID,
-                TvContract.WatchNextPrograms.COLUMN_PACKAGE_NAME,
-                TvContract.WatchNextPrograms.COLUMN_TITLE,
-                TvContract.WatchNextPrograms.COLUMN_SHORT_DESCRIPTION,
-                TvContract.WatchNextPrograms.COLUMN_WATCH_NEXT_TYPE,
-                TvContract.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS,
-                TvContract.WatchNextPrograms.COLUMN_LAST_PLAYBACK_POSITION_MILLIS,
-                TvContract.WatchNextPrograms.COLUMN_DURATION_MILLIS,
-                TvContract.WatchNextPrograms.COLUMN_INTENT_URI,
-                TvContract.WatchNextPrograms.COLUMN_POSTER_ART_URI
-            };
 
-            android.database.Cursor cursor = getContentResolver().query(
+        String[] projection = {
+            TvContract.WatchNextPrograms._ID,
+            TvContract.WatchNextPrograms.COLUMN_PACKAGE_NAME,
+            TvContract.WatchNextPrograms.COLUMN_TITLE,
+            TvContract.WatchNextPrograms.COLUMN_SHORT_DESCRIPTION,
+            TvContract.WatchNextPrograms.COLUMN_WATCH_NEXT_TYPE,
+            TvContract.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS,
+            TvContract.WatchNextPrograms.COLUMN_LAST_PLAYBACK_POSITION_MILLIS,
+            TvContract.WatchNextPrograms.COLUMN_DURATION_MILLIS,
+            TvContract.WatchNextPrograms.COLUMN_INTENT_URI,
+            TvContract.WatchNextPrograms.COLUMN_POSTER_ART_URI
+        };
+
+        try (android.database.Cursor cursor = getContentResolver().query(
                 TvContract.WatchNextPrograms.CONTENT_URI,
                 projection,
                 null,
                 null,
-                TvContract.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS + " DESC LIMIT 20"
-            );
+                TvContract.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS + " DESC")) {
 
-            if (cursor != null) {
-                while (cursor.moveToNext()) {
-                    Map<String, Object> map = new HashMap<>();
-                    map.put("id", cursor.getLong(cursor.getColumnIndexOrThrow(TvContract.WatchNextPrograms._ID)));
-                    map.put("packageName", cursorStringOrEmpty(cursor, TvContract.WatchNextPrograms.COLUMN_PACKAGE_NAME));
-                    map.put("title", cursorStringOrEmpty(cursor, TvContract.WatchNextPrograms.COLUMN_TITLE));
-                    map.put("description", cursorStringOrEmpty(cursor, TvContract.WatchNextPrograms.COLUMN_SHORT_DESCRIPTION));
-                    map.put("watchNextType", cursor.getInt(cursor.getColumnIndexOrThrow(TvContract.WatchNextPrograms.COLUMN_WATCH_NEXT_TYPE)));
-                    map.put("lastEngagementTime", cursor.getLong(cursor.getColumnIndexOrThrow(TvContract.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS)));
-                    map.put("playbackPosition", cursor.getLong(cursor.getColumnIndexOrThrow(TvContract.WatchNextPrograms.COLUMN_LAST_PLAYBACK_POSITION_MILLIS)));
-                    map.put("duration", cursor.getLong(cursor.getColumnIndexOrThrow(TvContract.WatchNextPrograms.COLUMN_DURATION_MILLIS)));
-                    map.put("intentUri", cursorStringOrEmpty(cursor, TvContract.WatchNextPrograms.COLUMN_INTENT_URI));
-                    map.put("posterArtUri", cursorStringOrEmpty(cursor, TvContract.WatchNextPrograms.COLUMN_POSTER_ART_URI));
-                    list.add(map);
-                }
-                cursor.close();
+            if (cursor == null) {
+                return list;
+            }
+
+            final int limit = 20;
+            int row = 0;
+            while (row < limit && cursor.moveToNext()) {
+                row++;
+
+                Map<String, Object> map = new HashMap<>();
+                map.put("id", cursor.getLong(cursor.getColumnIndexOrThrow(TvContract.WatchNextPrograms._ID)));
+                map.put("packageName", cursorStringOrEmpty(cursor, TvContract.WatchNextPrograms.COLUMN_PACKAGE_NAME));
+                map.put("title", cursorStringOrEmpty(cursor, TvContract.WatchNextPrograms.COLUMN_TITLE));
+                map.put("description", cursorStringOrEmpty(cursor, TvContract.WatchNextPrograms.COLUMN_SHORT_DESCRIPTION));
+                map.put("watchNextType", cursor.getInt(cursor.getColumnIndexOrThrow(TvContract.WatchNextPrograms.COLUMN_WATCH_NEXT_TYPE)));
+                map.put("lastEngagementTime", cursor.getLong(cursor.getColumnIndexOrThrow(TvContract.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS)));
+                map.put("playbackPosition", cursor.getLong(cursor.getColumnIndexOrThrow(TvContract.WatchNextPrograms.COLUMN_LAST_PLAYBACK_POSITION_MILLIS)));
+                map.put("duration", cursor.getLong(cursor.getColumnIndexOrThrow(TvContract.WatchNextPrograms.COLUMN_DURATION_MILLIS)));
+                map.put("intentUri", cursorStringOrEmpty(cursor, TvContract.WatchNextPrograms.COLUMN_INTENT_URI));
+                map.put("posterArtUri", cursorStringOrEmpty(cursor, TvContract.WatchNextPrograms.COLUMN_POSTER_ART_URI));
+                list.add(map);
             }
         } catch (Exception e) {
             e.printStackTrace();
         }
+
         return list;
     }
 

--- a/lib/flauncher.dart
+++ b/lib/flauncher.dart
@@ -77,16 +77,29 @@ class _FLauncherState extends State<FLauncher> {
                 child: Consumer<AppsService>(
                   builder: (context, appsService, _) {
                     if (appsService.initialized) {
-                      return SingleChildScrollView(
-                        physics: const ClampingScrollPhysics(),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            const ContinueWatchingRow(),
-                            _sections(appsService.launcherSections),
-                          ],
-                        ),
-                      );
+                      return Selector<WatchNextService, bool>(
+                        selector: (_, watchNext) => watchNext.programs.isNotEmpty,
+                        builder: (context, hasContinuingPrograms, _) =>
+                            Selector<SettingsService, bool>(
+                              selector: (_, settings) => settings.showContinueWatching,
+                              builder: (context, showContinueWatching, _) =>
+                                  SingleChildScrollView(
+                                    physics: const ClampingScrollPhysics(),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        const ContinueWatchingRow(),
+                                        _sections(
+                                            appsService.launcherSections,
+                                            continueWatchingActive:
+                                                showContinueWatching &&
+                                                hasContinuingPrograms),
+                                      ],
+                                    ),
+                                  ),
+                            ),
+                    );
                     }
                     else {
                       return _emptyState(context);
@@ -101,11 +114,7 @@ class _FLauncherState extends State<FLauncher> {
     ),
   );
 
-  Widget _sections(List<LauncherSection> sections) {
-    final settingsService = Provider.of<SettingsService>(context, listen: false);
-    final watchNextService = Provider.of<WatchNextService>(context, listen: false);
-    final bool continueWatchingActive = settingsService.showContinueWatching && watchNextService.programs.isNotEmpty;
-
+  Widget _sections(List<LauncherSection> sections, {bool continueWatchingActive = false}) {
     List<Widget> children = [];
     bool firstCategoryFound = continueWatchingActive;
 


### PR DESCRIPTION
Fixes https://github.com/leanbitlab-org/LtvLauncher/issues/7, https://github.com/leanbitlab-org/LtvLauncher/issues/136

### Fixing "Continue Watching" row
`getWatchNextPrograms` was crashing with

```
09-05 22:59:08.010  1509  1509 W System.err: java.lang.IllegalArgumentException: Illegal field in sort order last_engagement_time_utc_millis DESC LIMIT 20
09-05 22:59:08.011  1509  1509 W System.err:    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:172)
09-05 22:59:08.011  1509  1509 W System.err:    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:142)
09-05 22:59:08.011  1509  1509 W System.err:    at android.content.ContentProviderProxy.query(ContentProviderNative.java:495)
09-05 22:59:08.011  1509  1509 W System.err:    at android.content.ContentResolver.query(ContentResolver.java:1229)
09-05 22:59:08.011  1509  1509 W System.err:    at android.content.ContentResolver.query(ContentResolver.java:1161)
09-05 22:59:08.011  1509  1509 W System.err:    at android.content.ContentResolver.query(ContentResolver.java:1117)
09-05 22:59:08.011  1509  1509 W System.err:    at com.leanbitlab.ltvL.MainActivity.getWatchNextPrograms(MainActivity.java:1152)
```

This removes `LIMIT 20` from the sort order and manually limits the rows while iterating over the Cursor. I tried to use the  [QUERY_ARG_LIMIT](https://developer.android.com/reference/android/content/ContentResolver#QUERY_ARG_LIMIT) parameter, but that didn't appear to work. My Android TV just ignored the limit. I think this table is small anyway, so I don't think performance will be too bad.

The other thing is the thumbnails didn't load for my recently played programs. This is because the `COLUMN_POSTER_ART_URI`s were HTTP URLs. Fixing this would require the `android.permission.INTERNET` permission, so I figured I would leave that out. If adding that permission isn't a problem, I don't mind adding the fix to this PR.

### Fixing Scrolling into "Continue Watching"

Scrolling into the "Continue Watching" row from below was broken on first load because the sections weren't updating properly. The sections were built before the "Continue Watching" data came back. I made changes to make sure the sections update when there is a change in the visibility of "Continue Watching" row
