### PR TITLE
Keep status bar icons still when focus moves

### DIFF
--- a/lib/widgets/focus_aware_app_bar.dart
+++ b/lib/widgets/focus_aware_app_bar.dart
@@ -326,9 +326,13 @@ class _FocusableIconButtonState extends State<_FocusableIconButton> {
             decoration: BoxDecoration(
               color: _focused ? Colors.black.withOpacity(0.3) : Colors.transparent,
               borderRadius: BorderRadius.circular(8),
-              border: _focused
-                ? Border.all(color: Theme.of(context).colorScheme.primary, width: 2)
-                : null,
+              // Always reserve the border width: a BoxDecoration border adds to the
+              // Container's padding, so toggling it between null and 2px would resize
+              // the button and shift its siblings horizontally on every focus change.
+              border: Border.all(
+                color: _focused ? Theme.of(context).colorScheme.primary : Colors.transparent,
+                width: 2,
+              ),
               boxShadow: _focused
                 ? const [BoxShadow(color: Colors.black54, blurRadius: 8, spreadRadius: 1)]
                 : null,

--- a/lib/widgets/network_widget.dart
+++ b/lib/widgets/network_widget.dart
@@ -146,9 +146,11 @@ class _NetworkIconButtonState extends State<_NetworkIconButton> {
           decoration: BoxDecoration(
             color: _focused ? Colors.black.withOpacity(0.3) : Colors.transparent,
             borderRadius: BorderRadius.circular(8),
-            border: _focused
-                ? Border.all(color: Theme.of(context).colorScheme.primary, width: 2)
-                : null,
+            // Constant border width so focus changes never resize the widget.
+            border: Border.all(
+              color: _focused ? Theme.of(context).colorScheme.primary : Colors.transparent,
+              width: 2,
+            ),
             boxShadow: _focused
                 ? const [BoxShadow(color: Colors.black54, blurRadius: 8, spreadRadius: 1)]
                 : null,

--- a/lib/widgets/weather_status_bar_widget.dart
+++ b/lib/widgets/weather_status_bar_widget.dart
@@ -77,7 +77,8 @@ class _WeatherStatusBarWidgetState extends State<WeatherStatusBarWidget> {
                         color: _focused
                             ? theme.colorScheme.primary
                             : (isWarning ? Colors.amber.withOpacity(0.4) : Colors.white.withOpacity(0.12)),
-                        width: _focused ? 2 : 1,
+                        // Constant width: a 1px->2px change resizes the chip and shifts its neighbours.
+                        width: 2,
                       ),
                       boxShadow: _focused
                           ? [


### PR DESCRIPTION
## Problem

Moving focus between the Settings, Inputs and Wi-Fi icons in the status bar makes the *other* icons jump sideways. On a 1080p Sony Bravia (Android TV 9) the unfocused icons move about 8 px each time focus steps to a neighbour.

## Cause

`_FocusableIconButton` in `focus_aware_app_bar.dart`, and the same pattern in `network_widget.dart`, only add their 2 px focus border while focused (`border: _focused ? Border.all(...) : null`). A `BoxDecoration` border contributes to the `Container`'s padding, so the focused widget grows by 4 px in each axis and relayouts its siblings. The weather chip does a milder version by switching its border from 1 px to 2 px.

## Fix

Always reserve the border width and only change its colour: transparent when unfocused, the accent colour when focused. Same look, no relayout. Three files, no behaviour change beyond the layout.

## Evidence

Top half is before, bottom half after; focus steps Settings → Inputs → Wi-Fi. Dashed guides mark where the icons rest after the fix.

![focus shift before/after](https://raw.githubusercontent.com/gregmarra/LtvLauncher/evidence/status-bar-focus/evidence/focus-shift-before-after.gif)

Measured left edge of the *Inputs* glyph on the TV (1920×1080):

| Focus on | Before | After |
|---|---|---|
| Settings | 146 px | 150 px |
| Wi-Fi | 138 px | 150 px |

Static frames: [focus-shift-frames.png](https://raw.githubusercontent.com/gregmarra/LtvLauncher/evidence/status-bar-focus/evidence/focus-shift-frames.png). Captures live on an `evidence/status-bar-focus` branch of my fork so this PR carries no binaries.

Related: #138 aligns the settings glyph with the app tiles; independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
