### PR TITLE
Align the settings icon with the left edge of the app tiles

### DIFF
--- a/lib/widgets/focus_aware_app_bar.dart
+++ b/lib/widgets/focus_aware_app_bar.dart
@@ -87,6 +87,10 @@ class FocusAwareAppBarState extends State<FocusAwareAppBar>
       },
       child: RepaintBoundary(
         child: AppBar(
+          // Line the settings glyph up with the left edge of the app tiles below
+          // (sections indent 16 + 8 card margin + 8 tile inset = 32dp; the icon
+          // button adds 4 padding + 2 border + 2 glyph inset, so start at 24).
+          titleSpacing: 24,
           elevation: 0,
           scrolledUnderElevation: 0,
           backgroundColor: Colors.transparent,


### PR DESCRIPTION
## What

The status bar's title row starts at the `AppBar` default `titleSpacing` of 16 dp, which puts the settings glyph at 24 dp, while the app tiles in the sections below start at 32 dp (16 section indent + 8 card margin + 8 tile inset). The clock chip on the right already ends exactly on the tiles' right edge, so the left side was the only part of the bar not lined up with the content column.

This sets `titleSpacing: 24` so the settings glyph lands on the 32 dp content edge. The 16 dp spacing between the status bar icons is unchanged, and nothing else moves.

## Evidence

Top half before, bottom half after; the dashed guide is the left edge of the first app tile. Captured on a 1080p Sony Bravia (Android TV 9, 2 px/dp).

![gear alignment before/after](https://raw.githubusercontent.com/gregmarra/LtvLauncher/evidence/status-bar-focus/evidence/gear-alignment-before-after.gif)

| | Gear glyph left edge | First tile left edge |
|---|---|---|
| Before | 48 px (24 dp) | 64 px (32 dp) |
| After | 65 px (32 dp) | 64 px (32 dp) |

Static frames: [gear-alignment-frames.png](https://raw.githubusercontent.com/gregmarra/LtvLauncher/evidence/status-bar-focus/evidence/gear-alignment-frames.png).

Independent of #137 (the focus-shift fix); the before captures here already include that fix so this PR shows only the alignment change. Happy to drop this one if you prefer the current inset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)