### PR TITLE
Keep app icons with their names when the Applications list changes

### DIFF
--- a/lib/widgets/settings/applications_panel_page.dart
+++ b/lib/widgets/settings/applications_panel_page.dart
@@ -261,6 +261,7 @@ class _TVTab extends StatelessWidget {
                 .asMap()
                 .entries
                 .map((entry) => EnsureVisible(
+                      key: ValueKey(entry.value.packageName),
                       alignment: 0.5,
                       child: _AppListItem(entry.value, autofocus: entry.key == 0, isFirst: entry.key == 0),
                     ))
@@ -283,6 +284,7 @@ class _SideloadedTab extends StatelessWidget {
                 .asMap()
                 .entries
                 .map((entry) => EnsureVisible(
+                      key: ValueKey(entry.value.packageName),
                       alignment: 0.5,
                       child: _AppListItem(entry.value, autofocus: entry.key == 0, isFirst: entry.key == 0),
                     ))
@@ -311,6 +313,7 @@ class _FavoritesTab extends StatelessWidget {
                 .asMap()
                 .entries
                 .map((entry) => EnsureVisible(
+                      key: ValueKey(entry.value.packageName),
                       alignment: 0.5,
                       child: _AppListItem(entry.value, autofocus: entry.key == 0, isFirst: entry.key == 0),
                     ))
@@ -333,6 +336,7 @@ class _HiddenTab extends StatelessWidget {
                 .asMap()
                 .entries
                 .map((entry) => EnsureVisible(
+                      key: ValueKey(entry.value.packageName),
                       alignment: 0.5,
                       child: _AppListItem(entry.value, autofocus: entry.key == 0, isFirst: entry.key == 0),
                     ))
@@ -420,6 +424,14 @@ class _AppListItemState extends State<_AppListItem>
 
         _focusNode.requestFocus();
       });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant _AppListItem oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.application.packageName != widget.application.packageName) {
+      _iconLoadFuture = _loadAppIcon(Provider.of<AppsService>(context, listen: false));
     }
   }
 


### PR DESCRIPTION
## Problem

In Settings > Applications, hiding an app (or anything else that shrinks the list) leaves the icons out of step with the names: the names shift up, the icons stay where they were. Each further hide makes it worse.

## Cause

Each row is a `StatefulWidget` (`_AppListItem`) whose State loads its icon once in `initState` into `_iconLoadFuture`. The four tab lists build a plain `ListView(children: …)` with no keys, so when the list changes Flutter reuses each row's State *by position*: `build()` reads the new app's name from the widget, but the icon future still belongs to the app that used to sit in that slot.

## Fix

- Key each row by package name (on the `EnsureVisible` wrapper, the list's direct child) so State moves with its app.
- Add `didUpdateWidget` to the row State to reload the icon if a row is ever handed a different package. Belt and braces for any other path that rebuilds the list.

## Evidence

Android TV emulator (API 36). Left/before: stock build. Right/after: this branch. Hiding three apps in a row; by the third hide the stock build shows Settings wearing the TV icon.

![hidden apps icons before/after](https://raw.githubusercontent.com/gregmarra/LtvLauncher/evidence/status-bar-focus/evidence/hidden-apps-icons-before-after.gif)

[MP4 version](https://raw.githubusercontent.com/gregmarra/LtvLauncher/evidence/status-bar-focus/evidence/hidden-apps-icons-before-after.mp4) · [static frames](https://raw.githubusercontent.com/gregmarra/LtvLauncher/evidence/status-bar-focus/evidence/hidden-apps-icons-frames.png)

Captures live on an `evidence/status-bar-focus` branch of my fork so this PR carries no binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)