### PR TITLE
Sort newly installed apps into their category order

### DIFF
--- a/lib/providers/apps_service.dart
+++ b/lib/providers/apps_service.dart
@@ -544,8 +544,8 @@ class AppsService extends ChangeNotifier {
 
     await _database.insertAppsCategories(batch);
 
+    sortCategory(categoryFound); // also for new apps, which arrive without notify
     if (shouldNotifyListeners) {
-      sortCategory(categoryFound);
       notifyListeners();
     }
   }


### PR DESCRIPTION
## Problem

With a section sorted alphabetically (or by last used), a newly installed app appears at the *end* of the section and stays there until a restart or until the section is edited.

## Cause

`AppsService.addToCategory` appends the app with the next manual order and only calls `sortCategory` when `shouldNotifyListeners` is true. The `PACKAGE_ADDED` handler calls it with `shouldNotifyListeners: false`, so the sort is skipped for exactly the case where a new app arrives.

## Fix

Sort unconditionally after inserting; only the `notifyListeners()` call stays behind the flag. One-line change in `apps_service.dart`.

## Evidence

Android TV emulator (API 36), TV Apps section set to Alphabetical, then installing "File Manager". Top/before: stock build appends it after YouTube Music. Bottom/after: this branch sorts it into first position.

![new app sort before/after](https://raw.githubusercontent.com/gregmarra/LtvLauncher/evidence/status-bar-focus/evidence/new-app-sort-before-after.gif)

[static frames](https://raw.githubusercontent.com/gregmarra/LtvLauncher/evidence/status-bar-focus/evidence/new-app-sort-frames.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)